### PR TITLE
README.md内のPages URLを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A project based learning activity for people who are getting started with Git and GitHub.
 
-You can play the game at: https://githubschool.github.io/github-games/
+You can play the game at: https://org-mitsuzono-training20250418.github.io/github-games-mitsuzono/
 
 >> _*SUPPORTED BROWSERS*: Chrome, Firefox, Safari, Opera and IE9+_
 


### PR DESCRIPTION
This pull request updates the `README.md` file to reflect a change in the URL for the GitHub Games project.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5): Updated the game URL to `https://org-mitsuzono-training20250418.github.io/github-games-mitsuzono/` to point to the new organization-specific deployment.